### PR TITLE
Fixing Dates

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Course website for CS480, Section 10 (Spring 2019)
+# Course website for CS480, Section 10 (Spring 2020)
 
 
 This repository contains code and content for a website for one of the courses

--- a/_includes/daily/l8.markdown
+++ b/_includes/daily/l8.markdown
@@ -35,7 +35,7 @@ Due as soon as possible (but definitely by the end of Tuesday):
   - go back to the page Wednesday morning to cast your vote on
     additional questions if you like them
 
-Due by the end of the week (Feb. 29):
+Due by the end of the week (Mar. 1):
 - reflect on your goals for open source contributions, your skills and your interests in the
 `taking_stock` repository in the course organization (you should see your own private repository for this)
 - make your week 5 blog post


### PR DESCRIPTION
README markdown file in the ossd_s20 repo has Spring 2019 instead of Spring 2020, which I changed.  Then for the daily, it says by the end of this week (Feb. 29) instead of (Mar. 1).  Feb 29 was a Saturday and not the end of the week like Sunday, which is when all of the other assignments were due on.