### PR TITLE
Updated Withdraw Deadline

### DIFF
--- a/_includes/daily/change_4_3.markdown
+++ b/_includes/daily/change_4_3.markdown
@@ -10,7 +10,7 @@ Fri, 4/3
 <div class="column_recitation">
 <p markdown="block">
 
-Last day to withdraw from the class with W grade.
+Last day to withdraw from the class with W grade has now been extended to May 12th, 2020. 
 
 </p>
 </div>


### PR DESCRIPTION
Due to current circumstances, academic deadlines like the when to withdraw from courses have been extended. Addressing issue #23 